### PR TITLE
Expose HTTP response code to PHP SDK

### DIFF
--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -16,6 +16,11 @@ class CurlClient
      */
     private $_requestHeaders = array();
 
+    /**
+     * @var int the last HTTP status code received
+     */
+    private $_lastStatusCode = null;
+
     public function __construct($apiKey,$siteID)
     {
         $this->_setRequestHeader("Api-key", $apiKey);
@@ -200,10 +205,21 @@ class CurlClient
         curl_setopt($curlHandle, CURLOPT_TIMEOUT, 60);
 
         $result = curl_exec($curlHandle);
+        $this->_lastStatusCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
         curl_close($curlHandle);
 
         unset($this->_requestHeaders["Content-Type"]);
 
         return $result;
+    }
+
+    /**
+     * @brief get the last HTTP status code received
+     *
+     * @return int
+     */
+    public function getLastStatusCode()
+    {
+        return $this->_lastStatusCode;
     }
 }

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -188,7 +188,7 @@ class CurlClient
 
             case "delete":
                 curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
-                if ($this->_requestHeaders["Content-Type"] == "Content-Type: application/json")
+                if (array_key_exists("Content-Type", $this->_requestHeaders) && $this->_requestHeaders["Content-Type"] == "Content-Type: application/json")
                 {
                     curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $requestParams);
                 }

--- a/src/Ontraport.php
+++ b/src/Ontraport.php
@@ -95,6 +95,11 @@ class Ontraport
         return $client->httpRequest($requestParams, $url, $method, $requiredParams, $options);
     }
 
+    public function getLastStatusCode()
+    {
+        return $this->getHttpClient()->getLastStatusCode();
+    }
+
     /**
      * @brief constructs an api endpoint
      *

--- a/src/Ontraport.php
+++ b/src/Ontraport.php
@@ -95,6 +95,11 @@ class Ontraport
         return $client->httpRequest($requestParams, $url, $method, $requiredParams, $options);
     }
 
+    /**
+     * @brief gets the last HTTP status code received by the HTTP Client
+     *
+     * @return int
+     */
     public function getLastStatusCode()
     {
         return $this->getHttpClient()->getLastStatusCode();


### PR DESCRIPTION
Regarding issue #3, this patch fetches the HTTP status code from the curl handler before it is closed and then makes it available to calling code through an OntraportAPI public method so that non-successful responses can be programmatically evaluated.

Although I ultimately think it would be nice if every PHP SDK response contained a response code and then a response from the API, I assumed any changes to return values are undesirable and so went this route. Any thoughts?