### PR TITLE
Fix php notice issued when calling delete

### DIFF
--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -183,7 +183,7 @@ class CurlClient
 
             case "delete":
                 curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
-                if ($this->_requestHeaders["Content-Type"] == "Content-Type: application/json")
+                if (array_key_exists("Content-Type", $this->_requestHeaders) && $this->_requestHeaders["Content-Type"] == "Content-Type: application/json")
                 {
                     curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $requestParams);
                 }


### PR DESCRIPTION
Calling a delete method without declaring a Content-Type results in a PHP notice for trying to access the undeclared array index. Added the same check you were using further up in line 155.