### PR TITLE
Removed gateway_id and invoice_template require

### DIFF
--- a/src/Transactions.php
+++ b/src/Transactions.php
@@ -203,8 +203,6 @@ class Transactions extends BaseApi
         $requiredParams = array(
             "contact_id",
             "chargeNow",
-            "invoice_template",
-            "gateway_id",
             "offer"
         );
         return $this->client->request($requestParams, $this->_mainTransactionEndpoint . "/" . self::PROCESS_MANUAL, "post", $requiredParams, $options);


### PR DESCRIPTION
Per Ontraport API docs: https://api.ontraport.com/doc/#log-a-transaction

Neither gateway_id nor invoice_template should be required keys when the chargeNow value is set to chargeLog. I considered changing the code to inspect chargeNow and then update the required keys if it finds this to be a log, but reasoned that it's probably better to leave that validation to the REST end of the API and let the error come back to the PHP caller organically. Thoughts?

Separately, I notice that Ontraport commits have been stripping trailing newlines from file s, but it's a pretty widely accepted good practice to leave them. 