### PR TITLE
Keep below the API rate limit

### DIFF
--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -32,7 +32,7 @@ class CurlClient
     /**
      * @var array of headers received with HTTP responses
      */
-    private $_responseHeaders = array();
+    private static $_responseHeaders = array();
 
     /**
      * @var bool keep the request rate below the API rate limit
@@ -337,7 +337,7 @@ class CurlClient
             file_put_contents($this->_logFile, $data, FILE_APPEND);
         }
 
-        $this->_responseHeaders = $headers;
+        self::$_responseHeaders = $headers;
 
         $this->_lastStatusCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
         if ($this->_lastStatusCode == self::HTTP_RATE_LIMIT)
@@ -390,20 +390,20 @@ class CurlClient
     private function _checkRateLimit()
     {
         // If no API calls have been made, no need to delay.
-        if (empty($this->_responseHeaders))
+        if (empty(self::$_responseHeaders))
         {
             return;
         }
 
         // Default the $limit and $remaining values if not set in the last response header.
         /** @var int $limit */
-        $limit = isset($this->_responseHeaders[self::RATE_LIMIT])
-                    ? (int)$this->_responseHeaders[self::RATE_LIMIT]
+        $limit = isset(self::$_responseHeaders[self::RATE_LIMIT])
+                    ? (int)self::$_responseHeaders[self::RATE_LIMIT]
                     : self::DEFAULT_RATE_LIMIT;
 
         /** @var int $remaining */
-        $remaining = isset($this->_responseHeaders[self::RATE_LIMIT_REMAINING])
-                        ? (int)$this->_responseHeaders[self::RATE_LIMIT_REMAINING]
+        $remaining = isset(self::$_responseHeaders[self::RATE_LIMIT_REMAINING])
+                        ? (int)self::$_responseHeaders[self::RATE_LIMIT_REMAINING]
                         : self::DEFAULT_RATE_LIMIT;
 
         // If no API calls have been made, no need to delay.

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -20,6 +20,9 @@ class CurlClient
     const HTTP_ERROR = 500;
 
     const RATE_LIMIT_RESET = "x-rate-limit-reset";
+    const RATE_LIMIT = "x-rate-limit";
+    const RATE_LIMIT_REMAINING = "x-rate-limit-remaining";
+    const DEFAULT_RATE_LIMIT = 180;
 
     /**
      * @var array of headers sent with HTTP requests
@@ -27,6 +30,15 @@ class CurlClient
     private $_requestHeaders = array();
 
     /**
+     * @var array of headers received with HTTP responses
+     */
+    private $_responseHeaders = array();
+
+    /**
+     * @var bool keep the request rate below the API rate limit
+     */
+    private $_keepBelowRateLimit;
+    
      * @var array of extra CURL options
      */
     private $_curlOptions = array();
@@ -36,9 +48,10 @@ class CurlClient
      */
     private $_lastStatusCode;
 
-    public function __construct($apiKey = "", $siteID = "")
+    public function __construct($apiKey = "", $siteID = "", $keepBelowRateLimit = true)
     {
         $this->setCredentials($apiKey, $siteID);
+        $this->_keepBelowRateLimit = $keepBelowRateLimit;
     }
 
     /**
@@ -196,6 +209,11 @@ class CurlClient
             return false;
         }
 
+        if ($this->_keepBelowRateLimit)
+        {
+            $this->_checkRateLimit();
+        }
+
         if ($options &&
             is_array($options) &&
             array_key_exists("headers", $options) &&
@@ -278,6 +296,8 @@ class CurlClient
 
         $result = curl_exec($curlHandle);
 
+        $this->_responseHeaders = $headers;
+
         $this->_lastStatusCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
         if ($this->_lastStatusCode == self::HTTP_RATE_LIMIT)
         {
@@ -324,5 +344,44 @@ class CurlClient
         $result = curl_exec($curlHandle);
         $this->_lastStatusCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
         return $result;
+    }
+
+    private function _checkRateLimit()
+    {
+        // If no API calls have been made, no need to delay.
+        if (empty($this->_responseHeaders))
+        {
+            return;
+        }
+
+        // Default the $limit and $remaining values if not set in the last response header.
+        /** @var int $limit */
+        $limit = isset($this->_responseHeaders[self::RATE_LIMIT])
+                    ? (int)$this->_responseHeaders[self::RATE_LIMIT]
+                    : self::DEFAULT_RATE_LIMIT;
+
+        /** @var int $remaining */
+        $remaining = isset($this->_responseHeaders[self::RATE_LIMIT_REMAINING])
+                        ? (int)$this->_responseHeaders[self::RATE_LIMIT_REMAINING]
+                        : self::DEFAULT_RATE_LIMIT;
+
+        // If no API calls have been made, no need to delay.
+        if ($limit == $remaining)
+        {
+            return;
+        }
+
+        // If we are below 5% remaining, sleep for 0.50 seconds.
+        if ($remaining / $limit < 0.05)
+        {
+            usleep(500000);
+            return;
+        }
+
+        // If we are below 10% remaining, sleep for 0.25 seconds.
+        if ($remaining / $limit < 0.1)
+        {
+            usleep(250000);
+        }
     }
 }

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -38,7 +38,8 @@ class CurlClient
      * @var bool keep the request rate below the API rate limit
      */
     private $_keepBelowRateLimit;
-    
+
+	/**
      * @var array of extra CURL options
      */
     private $_curlOptions = array();
@@ -303,7 +304,8 @@ class CurlClient
                 return $len;
             }
         );
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 60);
+        curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, 30);
+        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 60 * 2);
 
         /** ********** DEBUGGER ********** */
         if ($this->_debug) {

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -268,11 +268,13 @@ class CurlClient
             case "post":
                 curl_setopt($curlHandle, CURLOPT_POST, 1);
                 curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $requestParams);
+                $this->custom_request = '';
                 break;
 
             case "get":
                 curl_setopt($curlHandle, CURLOPT_HTTPGET, 1);
                 $url = $url."?".$requestParams;
+                $this->custom_request = '';
                 break;
 
             case "put":

--- a/src/ICurlResponse.php
+++ b/src/ICurlResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OntraportAPI;
+
+/**
+ * @property string Content
+ * @property int HttpCode
+ * @property int ErrorNumber
+ * @property string ErrorMessage
+ */
+interface ICurlResponse
+{
+}

--- a/src/MockCurlResponse.php
+++ b/src/MockCurlResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OntraportAPI;
+
+class MockCurlResponse
+{
+    public string $Method;
+
+    /** @var ICurlResponse */
+    public $Response;
+
+    /**
+     * @param string $method
+     * @param ICurlResponse|mixed $response
+     */
+    public function __construct(string $method, $response)
+    {
+        $this->Method = $method;
+        $this->Response = $response;
+    }
+}


### PR DESCRIPTION
Added the option to not exceed the API rate limit of 180 requests per minute. If the number of API requests is approaching the limit, short pauses are taken to prevent the code from reaching the limit. A short sleep of 0.25 seconds is added when the count remaining gets below 10%. When the count gets down to less than 5% remaining, a 0.5 second sleep is inserted before the next call. Since the limit is 3 per second, this pause will effectively prevent the program from reaching the limit.